### PR TITLE
feat: collision explosion player

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
+  reactStrictMode: false,
 };
 
 module.exports = nextConfig;

--- a/src/models/player.ts
+++ b/src/models/player.ts
@@ -43,15 +43,14 @@ export class Player extends Character {
     this.handleInput();
   }
 
-  //敵とぶつかった時
-  collideWithEnemy(stockText: Phaser.GameObjects.Text, gameOverText: Phaser.GameObjects.Text) {
+  damagedPlayer(stockText: Phaser.GameObjects.Text, gameOverText: Phaser.GameObjects.Text) {
     this.scene.cameras.main.shake(1000, 0.001);
     this.setTintFill(0xff0000);
     //残機を減らす
     this.setRemainingLives = this.getRemainingLives - 1;
 
     //残機の表示を更新
-    stockText.setText('Stock: ' + this.getRemainingLives);
+    stockText.setText('Stock ' + this.getRemainingLives);
 
     //残機が0になったらGAME OVER
     //note:0未満では？


### PR DESCRIPTION
## 概要
- 爆風に当たり判定を追加する
- プレイヤーへの当たり判定処理のリファクタリング

### 内容
- player.ts→爆弾の当たりと敵への当たりの処理を統一
- GameScene.ts→爆風の描写と当たり判定の処理

## 今後の課題
- 爆風を大きくする機能
- 敵に爆風が当たった時の処理
- ヒットした後の色を元に戻す

## 参考文献
爆風にヒットしたかどうか判別する変数によって1回だけ処理を実行する
https://tech.pjin.jp/blog/2018/10/25/unity_update_call-once/