### PR TITLE
Feat/hit condition

### DIFF
--- a/public/assets/stage1.json
+++ b/public/assets/stage1.json
@@ -104,7 +104,7 @@
                  "visible":true,
                  "width":32,
                  "x":37,
-                 "y":603
+                 "y":150
                 }],
          "opacity":1,
          "type":"objectgroup",

--- a/src/models/character.ts
+++ b/src/models/character.ts
@@ -13,7 +13,6 @@ interface GameObject {
   set setSpeed(value: number); //速さを設定
   accelerate(value: number): void; //加速
   get getLives(): number; //残機の数
-  takeDamage():void; //ダメージを受けた時の処理
 }
 
 export class Character

--- a/src/models/character.ts
+++ b/src/models/character.ts
@@ -8,13 +8,12 @@ interface GameObject {
   get getDirection(): number; //向きを取得
   get getPosition(): Position; //位置を取得
   get getSpeed(): number; //速さを取得
-  get getRemainingLives(): number; //残機を取得
-  // getHP(): number;
   isAlive(): boolean; //残機があるかどうか
   set setDirection(value: number); //向きを設定
   set setSpeed(value: number); //速さを設定
-  set setRemainingLives(value: number); //残機を設定
   accelerate(value: number): void; //加速
+  get getLives(): number; //残機の数
+  takeDamage():void; //ダメージを受けた時の処理
 }
 
 export class Character
@@ -27,7 +26,7 @@ export class Character
   private speed = 0;
   // 0:up, 1:right, 2:down, 3:left
   private direction = 2;
-  private remainingLives = 0; // protectedにしてset/getを不要にした方が扱いやすいかも
+  protected lives;
 
   constructor(
     params: {
@@ -35,9 +34,11 @@ export class Character
       x: number;
       y: number;
     },
-    type: string
+    type: string,
+    lives: number,
   ) {
     super(params.scene, params.x, params.y, type);
+    this.lives = lives;
   }
 
   public get getID():number{
@@ -55,20 +56,17 @@ export class Character
   public get getSpeed(): number {
     return this.speed;
   }
+  public get getLives(): number {
+    return this.lives;
+  }
   public set setSpeed(value: number) {
     this.speed = value;
   }
-  public get getRemainingLives(): number {
-    return this.remainingLives;
-  }
   public isAlive(): boolean {
-    return this.remainingLives >= 0;
+    return this.lives >= 0;
   }
   public set setDirection(value: number) {
     this.direction = value;
-  }
-  public set setRemainingLives(value: number){
-    this.remainingLives = value;
   }
 
   public accelerate(value: number): void {

--- a/src/models/character.ts
+++ b/src/models/character.ts
@@ -8,11 +8,13 @@ interface GameObject {
   get getDirection(): number; //向きを取得
   get getPosition(): Position; //位置を取得
   get getSpeed(): number; //速さを取得
-  isAlive(): boolean; //残機があるかどうか
+  get getLives(): number; //残機の数
+  get getHit(): boolean;
   set setDirection(value: number); //向きを設定
   set setSpeed(value: number); //速さを設定
+  set setHit(value: boolean);
+  isAlive(): boolean; //残機があるかどうか
   accelerate(value: number): void; //加速
-  get getLives(): number; //残機の数
 }
 
 export class Character
@@ -26,6 +28,7 @@ export class Character
   // 0:up, 1:right, 2:down, 3:left
   private direction = 2;
   protected lives;
+  protected hit = false;
 
   constructor(
     params: {
@@ -58,16 +61,23 @@ export class Character
   public get getLives(): number {
     return this.lives;
   }
+  public get getHit(): boolean {
+    return this.hit;
+  }
+
   public set setSpeed(value: number) {
     this.speed = value;
-  }
-  public isAlive(): boolean {
-    return this.lives >= 0;
   }
   public set setDirection(value: number) {
     this.direction = value;
   }
-
+  public set setHit(value: boolean) {
+    this.hit = value;
+  }
+  
+  public isAlive(): boolean {
+    return this.lives >= 0;
+  }
   public accelerate(value: number): void {
     this.setSpeed = this.getSpeed + value;
   }

--- a/src/models/character.ts
+++ b/src/models/character.ts
@@ -27,7 +27,7 @@ export class Character
   private speed = 0;
   // 0:up, 1:right, 2:down, 3:left
   private direction = 2;
-  private remainingLives = 0;
+  private remainingLives = 0; // protectedにしてset/getを不要にした方が扱いやすいかも
 
   constructor(
     params: {

--- a/src/models/enemy.ts
+++ b/src/models/enemy.ts
@@ -21,14 +21,14 @@ export class Enemy extends Character {
     //最初に動く方向をランダムにセット
     this.setDirection = getRandomInt(0, 4);
 
-    this.setRemainingLives = 2;
+    this.setRemainingLives = 1;
   }
 
   //GameObjectによってオーバーライドされる更新メソッド
   //このメソッドが何度も呼び出されるため、
   //この中にオブジェクトの位置や速度を変化させる記述を書いておくと、動きを付けられる
   update() {
-    this.moveRamdom();
+    // this.moveRamdom();
   }
 
   //ランダムな動き
@@ -71,9 +71,9 @@ export class Enemy extends Character {
   //爆風と重なった時
   overlapExplosion() {
     //残機を減らす
-    this.setRemainingLives = this.getRemainingLives - 1;
+    this.remainingLives--;
     //残機が0になったらオブジェクトを削除
-    if (this.getRemainingLives <= 0) {
+    if (this.remainingLives <= 0) {
       this.disableBody(true, true);
     }
   }

--- a/src/models/enemy.ts
+++ b/src/models/enemy.ts
@@ -5,12 +5,15 @@ import { Player } from './player';
 export class Enemy extends Character {
   private mode = 'complicated';
 
-  constructor(params: {
-    scene: Phaser.Scene;
-    x: number;
-    y: number;
-  }) {
-    super(params, 'enemy');
+  constructor(
+    params: {
+      scene: Phaser.Scene;
+      x: number;
+      y: number;
+    },
+    lives: number
+  ) {
+    super(params, 'enemy', lives);
     this.setSpeed = 80;
 
     //Arcade Physicsをゲームオブジェクトに追加
@@ -20,8 +23,6 @@ export class Enemy extends Character {
 
     //最初に動く方向をランダムにセット
     this.setDirection = getRandomInt(0, 4);
-
-    this.setRemainingLives = 1;
   }
 
   //GameObjectによってオーバーライドされる更新メソッド
@@ -69,11 +70,10 @@ export class Enemy extends Character {
   }
 
   //爆風と重なった時
-  overlapExplosion() {
-    //残機を減らす
-    this.setRemainingLives = this.getRemainingLives - 1;
+  damagedEnemy() {
+    this.lives--;
     //残機が0になったらオブジェクトを削除
-    if (this.getRemainingLives <= 0) {
+    if (this.lives <= 0) {
       this.disableBody(true, true);
     }
   }

--- a/src/models/enemy.ts
+++ b/src/models/enemy.ts
@@ -71,9 +71,9 @@ export class Enemy extends Character {
   //爆風と重なった時
   overlapExplosion() {
     //残機を減らす
-    this.remainingLives--;
+    this.setRemainingLives = this.getRemainingLives - 1;
     //残機が0になったらオブジェクトを削除
-    if (this.remainingLives <= 0) {
+    if (this.getRemainingLives <= 0) {
       this.disableBody(true, true);
     }
   }

--- a/src/models/player.ts
+++ b/src/models/player.ts
@@ -5,7 +5,7 @@ export class Player extends Character {
   private bombCounter: number;
   private bombPower:number;
   private playerColor:string;
-  private bombCapacity:number;
+  private bombCapacity:number; // Todo:bombCounterと機能が被ってるので後で削除する
   private playerScore:number;
 
   constructor(params: {
@@ -33,6 +33,7 @@ export class Player extends Character {
 
     // 初期設定の残機は３
     this.setRemainingLives = 3;
+    // this.remainingLives = 3;
   }
 
   public bombPowerUp() {

--- a/src/models/player.ts
+++ b/src/models/player.ts
@@ -3,17 +3,20 @@ import { Character } from './character';
 export class Player extends Character {
   private cursors: Phaser.Types.Input.Keyboard.CursorKeys;
   private bombCounter: number;
-  private bombPower:number;
-  private playerColor:string;
-  private bombCapacity:number; // Todo:bombCounterと機能が被ってるので後で削除する
-  private playerScore:number;
+  private bombPower: number;
+  private playerColor: string;
+  private bombCapacity: number; // Todo:bombCounterと機能が被ってるので後で削除する
+  private playerScore: number;
 
-  constructor(params: {
-    scene: Phaser.Scene;
-    x: number;
-    y: number;
-  }) {
-    super(params, 'player');
+  constructor(
+    params: {
+      scene: Phaser.Scene;
+      x: number;
+      y: number;
+    },
+    lives: number
+  ) {
+    super(params, 'player', lives);
     this.setSpeed = 120;
     // 上、下、左、右、スペース、シフトのキーを含むオブジェクトを作成して返す。
     this.cursors =
@@ -21,19 +24,15 @@ export class Player extends Character {
     this.bombCounter = 3;
     this.bombPower = 2;
 
-    this.playerColor = "blue";
+    this.playerColor = 'blue';
     this.bombCapacity = 1;
     this.bombPower = 1;
-    this.playerScore = 0
+    this.playerScore = 0;
 
     params.scene.add.existing(this);
     params.scene.physics.world.enable(this);
 
     this.body.maxVelocity = <any>{ x: 250, y: 250 };
-
-    // 初期設定の残機は３
-    this.setRemainingLives = 3;
-    // this.remainingLives = 3;
   }
 
   public bombPowerUp() {
@@ -44,18 +43,20 @@ export class Player extends Character {
     this.handleInput();
   }
 
-  damagedPlayer(stockText: Phaser.GameObjects.Text, gameOverText: Phaser.GameObjects.Text) {
+  damagedPlayer(
+    stockText: Phaser.GameObjects.Text,
+    gameOverText: Phaser.GameObjects.Text
+  ) {
     this.scene.cameras.main.shake(1000, 0.001);
     this.setTintFill(0xff0000);
-    //残機を減らす
-    this.setRemainingLives = this.getRemainingLives - 1;
+
+    this.lives--;
 
     //残機の表示を更新
-    stockText.setText('Stock ' + this.getRemainingLives);
+    stockText.setText('Stock ' + this.lives);
 
     //残機が0になったらGAME OVER
-    //note:0未満では？
-    if (this.getRemainingLives <= 0) {
+    if (this.lives <= 0) {
       // this.disableBody(true, true);
       gameOverText.setText('GAME OVER');
       setTimeout(() => this.scene.scene.restart(), 1000);
@@ -66,9 +67,9 @@ export class Player extends Character {
   overlapExplosion() {
     this.scene.cameras.main.shake(1000, 0.001);
     //残機を減らす
-    this.setRemainingLives = this.getRemainingLives - 1;
+    this.lives--;
     //残機が0になったらオブジェクトを削除
-    if (this.getRemainingLives <= 0) {
+    if (this.lives <= 0) {
       this.disableBody(true, true);
     }
   }
@@ -113,7 +114,10 @@ export class Player extends Character {
   }
 
   public placingBomb() {
-    return Phaser.Input.Keyboard.JustDown(this.cursors.space) && this.bombCounter > 0;
+    return (
+      Phaser.Input.Keyboard.JustDown(this.cursors.space) &&
+      this.bombCounter > 0
+    );
   }
   public decreaseBombCounter() {
     this.bombCounter--;
@@ -123,35 +127,35 @@ export class Player extends Character {
   }
 
   // setter,getter
-  public get getPlayerColor(): string{
+  public get getPlayerColor(): string {
     return this.playerColor;
   }
 
-  public set setPlayerColor(color:string){
-    this.playerColor = color
+  public set setPlayerColor(color: string) {
+    this.playerColor = color;
   }
 
-  public get getBombCapacity(): number{
+  public get getBombCapacity(): number {
     return this.bombCapacity;
   }
 
-  public set setBombCapacity(newCapacity:number){
+  public set setBombCapacity(newCapacity: number) {
     this.bombCapacity = newCapacity;
   }
 
-  public get getBombPower(): number{
+  public get getBombPower(): number {
     return this.bombPower;
   }
 
-  public set setBombPower(newPower:number){
+  public set setBombPower(newPower: number) {
     this.bombPower = newPower;
   }
 
-  public get getPlayerScore(): number{
+  public get getPlayerScore(): number {
     return this.playerScore;
   }
 
-  public set setPlayerScore(newScore:number){
+  public set setPlayerScore(newScore: number) {
     this.playerScore = newScore;
   }
 }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -87,7 +87,7 @@ export class GameScene extends Scene {
   init(data: { stageLevel: number }) {
     this.level = data.stageLevel;
   }
-  
+
   preload() {
     const width: string | number =
       this.scene.systems.game.config['width'];
@@ -157,19 +157,25 @@ export class GameScene extends Scene {
     const objectLayer = this.map.getObjectLayer('objects');
     objectLayer.objects.forEach((object) => {
       if (object.name === 'player') {
-        this.player = new Player({
-          scene: this,
-          x: object.x + 0,
-          y: object.y + 0,
-        });
-      }
-      if (object.name === 'enemy') {
-        this.enemies.add(
-          new Enemy({
+        this.player = new Player(
+          {
             scene: this,
             x: object.x + 0,
             y: object.y + 0,
-          })
+          },
+          3
+        );
+      }
+      if (object.name === 'enemy') {
+        this.enemies.add(
+          new Enemy(
+            {
+              scene: this,
+              x: object.x + 0,
+              y: object.y + 0,
+            },
+            1
+          )
         );
       }
     });
@@ -178,7 +184,7 @@ export class GameScene extends Scene {
     this.stockText = this.add.text(
       16,
       0,
-      `Stock ${this.player.getRemainingLives}`,
+      `Stock ${this.player.getLives}`,
       {
         fontSize: '32px',
       }
@@ -203,11 +209,10 @@ export class GameScene extends Scene {
       this.player,
       this.enemies,
       (
-        player: Phaser.Types.Physics.Arcade.GameObjectWithBody,
         enemy: Phaser.Types.Physics.Arcade.GameObjectWithBody
       ) => {
         //衝突した時の処理
-        player.damagedPlayer(
+        this.player.damagedPlayer(
           this.stockText,
           this.gameOverText
         );
@@ -219,11 +224,9 @@ export class GameScene extends Scene {
     this.physics.add.collider(
       this.player,
       this.explosion,
-      (
-        player: Phaser.Types.Physics.Arcade.GameObjectWithBody
-      ) => {
+      () => {
         if (this.hit) {
-          player.damagedPlayer(
+          this.player.damagedPlayer(
             this.stockText,
             this.gameOverText
           );
@@ -240,7 +243,7 @@ export class GameScene extends Scene {
         enemy: Phaser.Types.Physics.Arcade.GameObjectWithBody
       ) => {
         if (this.hit) {
-          enemy.overlapExplosion();
+          enemy.damagedEnemy();
         }
         this.hit = false;
       },

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -7,7 +7,6 @@ export class GameScene extends Scene {
   private width: number; //描画範囲(width)
   private height: number; //描画範囲(width)
   private player: Player; //プレイヤー
-  private hit: boolean;
   private enemies: Phaser.GameObjects.Group; //敵キャラのグループ
   // note:mapはcurrentMapとそれ以外みたいな保持の仕方もあり？
   private map: Phaser.Tilemaps.Tilemap; //タイルマップ（ステージ）
@@ -35,7 +34,6 @@ export class GameScene extends Scene {
       y: -1,
       existed: false,
     };
-    this.hit = true;
     this.timer = 0;
     this.isGameOver = false;
     this.isGameClear = false;
@@ -225,13 +223,13 @@ export class GameScene extends Scene {
       this.player,
       this.explosion,
       () => {
-        if (this.hit) {
+        if (!this.player.getHit) {
           this.player.damagedPlayer(
             this.stockText,
             this.gameOverText
           );
         }
-        this.hit = false;
+        this.player.setHit = true;
       },
       null,
       this
@@ -242,22 +240,14 @@ export class GameScene extends Scene {
       (
         enemy: Phaser.Types.Physics.Arcade.GameObjectWithBody
       ) => {
-        if (this.hit) {
+        if (!enemy.getHit) {
           enemy.damagedEnemy();
         }
-        this.hit = false;
+        enemy.setHit = true;
       },
       null,
       this
     );
-    //すり抜けた時（爆弾、アイテムなど）
-    // this.physics.add.overlap(
-    //   this.player,
-    //   this.bomb,
-    //   () => {
-    //     //すり抜けた時の処理(残機を減らす、アイテム取得)
-    //   }
-    // );
   }
 
   update() {
@@ -312,7 +302,7 @@ export class GameScene extends Scene {
           this.player.increaseBombCounter();
           window.setTimeout(() => {
             this.explosion.clear();
-            this.hit = true;
+            this.player.setHit = false;
           }, 600);
         }, 2000);
       }

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -37,9 +37,9 @@ export class GameScene extends Scene {
     };
     this.hit = true;
     this.timer = 0;
-    (this.isGameOver = false),
-      (this.isGameClear = false),
-      (this.stageName = 'first');
+    this.isGameOver = false;
+    this.isGameClear = false;
+    this.stageName = 'first';
   }
 
   // getter,setter
@@ -87,10 +87,7 @@ export class GameScene extends Scene {
   init(data: { stageLevel: number }) {
     this.level = data.stageLevel;
   }
-  // note:widthやheightの再宣言の理由
-  // note:データ型の理由
-  // note:コンストラクタで行わない理由
-
+  
   preload() {
     const width: string | number =
       this.scene.systems.game.config['width'];
@@ -155,7 +152,6 @@ export class GameScene extends Scene {
     this.initAnimation();
 
     //敵キャラたち
-    // note:12/28 コンストラクターでやらない理由
     this.enemies = this.add.group();
 
     const objectLayer = this.map.getObjectLayer('objects');
@@ -237,6 +233,20 @@ export class GameScene extends Scene {
       null,
       this
     );
+    this.physics.add.collider(
+      this.enemies,
+      this.explosion,
+      (
+        enemy: Phaser.Types.Physics.Arcade.GameObjectWithBody
+      ) => {
+        if (this.hit) {
+          enemy.overlapExplosion();
+        }
+        this.hit = false;
+      },
+      null,
+      this
+    );
     //すり抜けた時（爆弾、アイテムなど）
     // this.physics.add.overlap(
     //   this.player,
@@ -246,8 +256,6 @@ export class GameScene extends Scene {
     //   }
     // );
   }
-
-  // 爆弾を作る関数
 
   update() {
     //キー入力によってプレイヤーの位置を更新


### PR DESCRIPTION
## PRの目的
- 爆弾への当たり判定の状態を各キャラクターに持たせる
- 現状はシーン内で当たり判定を持っているので、プレイヤーと敵が同時に爆弾に当たった時の処理ができない

## 概要
- ヒットパラメーターの追加
- シーン内で処理

### 内容
- character.ts→変数hit/set/getを追加
- GameScene.ts→上記に伴う修正